### PR TITLE
Replaces bash cmd filter w/parameterization :snail:

### DIFF
--- a/Services/ServerManagementService.cs
+++ b/Services/ServerManagementService.cs
@@ -31,12 +31,15 @@ namespace TerminusDotNetCore.Services
         }
         private static async Task<string> RunBashCommand(string cmd, string user)
         {
-            string escapedCmd = cmd.Replace("\"", "\\\"");
             using (var bashProcess = Process.Start(
                 new ProcessStartInfo
                 {
                     FileName = "sudo",
-                    Arguments = $"-u {user} sh -c \"{escapedCmd}\"",
+                    ArgumentList = {
+                        "-u",
+                        $"{user}",
+                        $"{cmd}"
+                    },
                     UseShellExecute = false,
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,


### PR DESCRIPTION
still vulnerable; e.g. run `!bash \" touch #` and you won't get permission denied
fixing this so i stop messing with it
using ArgumentList from: 
https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.processstartinfo.argumentlist?view=net-5.0#System_Diagnostics_ProcessStartInfo_ArgumentList

ok that wont worry ok gave a nice day i see road man kindly please do the pull request into branch name penislmao